### PR TITLE
Various QOL and feature updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.0.0
+
+- `null` returned when parsing fails.
+- Year/month parsing changed to refer to local year/month
+    > For example, `1 month` resolves to 31 days in january, but only 28 in february. This ensures that `1 month` away from the nth day is always the nth day of the following month, and similarly for leap years.
+- Added `allowNegative` to set whether negative values are allowed. Parsing will fail if the final result is negative.
+
+
 ## 2.0.1
 
 - Initial version.

--- a/lib/src/human_duration_parser.dart
+++ b/lib/src/human_duration_parser.dart
@@ -30,6 +30,7 @@ Duration? parseStringToDuration(
   bool matchMinutes = true,
   bool matchSeconds = true,
   bool matchMilliSeconds = true,
+  bool allowNegative = true,
 }) {
   var duration = Duration.zero;
   bool parsed = false;
@@ -61,6 +62,10 @@ Duration? parseStringToDuration(
   }
 
   if (!parsed) {
+    return null;
+  }
+
+  if (!allowNegative && duration < Duration.zero) {
     return null;
   }
 

--- a/lib/src/human_duration_parser.dart
+++ b/lib/src/human_duration_parser.dart
@@ -21,7 +21,7 @@ Duration _computeMonths(int months) {
   return target.difference(now);
 }
 
-Duration parseStringToDuration(
+Duration? parseStringToDuration(
   String durationString, {
   bool matchYears = true,
   bool matchMonths = true,
@@ -32,6 +32,7 @@ Duration parseStringToDuration(
   bool matchMilliSeconds = true,
 }) {
   var duration = Duration.zero;
+  bool parsed = false;
 
   final elements = <RegExp, Duration Function(int amount)>{
     if (matchYears) yearsRegex: _computeYears,
@@ -54,8 +55,13 @@ Duration parseStringToDuration(
       final amount = int.tryParse(amountText!);
       if (amount != null) {
         duration += value(amount);
+        parsed = true;
       }
     }
+  }
+
+  if (!parsed) {
+    return null;
   }
 
   return duration;

--- a/lib/src/human_duration_parser.dart
+++ b/lib/src/human_duration_parser.dart
@@ -12,17 +12,15 @@ Duration addTwoDurations(Duration first, Duration second) {
 }
 
 Duration parseStringToDuration(
-    String durationString,
-    {
-      bool matchYears = true,
-      bool matchMonths = true,
-      bool matchDays = true,
-      bool matchHours = true,
-      bool matchMinutes = true,
-      bool matchSeconds = true,
-      bool matchMilliSeconds = true,
-    }
-) {
+  String durationString, {
+  bool matchYears = true,
+  bool matchMonths = true,
+  bool matchDays = true,
+  bool matchHours = true,
+  bool matchMinutes = true,
+  bool matchSeconds = true,
+  bool matchMilliSeconds = true,
+}) {
   var duration = Duration();
 
   if (matchYears) {

--- a/lib/src/human_duration_parser.dart
+++ b/lib/src/human_duration_parser.dart
@@ -7,6 +7,20 @@ final hoursRegex = RegExp(r"(\d+)([ ]*)(hours|hour|h)");
 final minutesRegex = RegExp(r"(\d+)([ ]*)(minutes|minute|min|m)");
 final secondsRegex = RegExp(r"(\d+)([ ]*)(seconds|second|secs|sec|s)");
 
+Duration _computeYears(int years) {
+  final now = DateTime.now();
+  final target = now.copyWith(year: now.year + years);
+
+  return target.difference(now);
+}
+
+Duration _computeMonths(int months) {
+  final now = DateTime.now();
+  final target = now.copyWith(month: now.month + months);
+
+  return target.difference(now);
+}
+
 Duration parseStringToDuration(
   String durationString, {
   bool matchYears = true,
@@ -20,8 +34,8 @@ Duration parseStringToDuration(
   var duration = Duration.zero;
 
   final elements = <RegExp, Duration Function(int amount)>{
-    if (matchYears) yearsRegex: (amount) => const Duration(days: 365) * amount,
-    if (matchMonths) monthsRegex: (amount) => const Duration(days: 30) * amount,
+    if (matchYears) yearsRegex: _computeYears,
+    if (matchMonths) monthsRegex: _computeMonths,
     if (matchDays) daysRegex: (amount) => const Duration(days: 1) * amount,
     if (matchHours) hoursRegex: (amount) => const Duration(hours: 1) * amount,
     if (matchMinutes) minutesRegex: (amount) => const Duration(minutes: 1) * amount,

--- a/lib/src/human_duration_parser.dart
+++ b/lib/src/human_duration_parser.dart
@@ -7,10 +7,6 @@ final hoursRegex = RegExp(r"(\d+)([ ]*)(hours|hour|h)");
 final minutesRegex = RegExp(r"(\d+)([ ]*)(minutes|minute|min|m)");
 final secondsRegex = RegExp(r"(\d+)([ ]*)(seconds|second|secs|sec|s)");
 
-Duration addTwoDurations(Duration first, Duration second) {
-  return Duration(milliseconds: first.inMilliseconds + second.inMilliseconds);
-}
-
 Duration parseStringToDuration(
   String durationString, {
   bool matchYears = true,
@@ -21,64 +17,29 @@ Duration parseStringToDuration(
   bool matchSeconds = true,
   bool matchMilliSeconds = true,
 }) {
-  var duration = Duration();
+  var duration = Duration.zero;
 
-  if (matchYears) {
-    final yearMatch = yearsRegex.firstMatch(durationString);
-    if (yearMatch != null) {
-      final yearNumber = yearMatch.group(1);
-      if (yearNumber != null) {
-        duration = addTwoDurations(duration, Duration(days: 365 * int.parse(yearNumber)));
-      }
-    }
-  }
+  final elements = <RegExp, Duration Function(int amount)>{
+    if (matchYears) yearsRegex: (amount) => const Duration(days: 365) * amount,
+    if (matchMonths) monthsRegex: (amount) => const Duration(days: 30) * amount,
+    if (matchDays) daysRegex: (amount) => const Duration(days: 1) * amount,
+    if (matchHours) hoursRegex: (amount) => const Duration(hours: 1) * amount,
+    if (matchMinutes) minutesRegex: (amount) => const Duration(minutes: 1) * amount,
+    if (matchSeconds) secondsRegex: (amount) => const Duration(seconds: 1) * amount,
+  };
 
-  if (matchMonths) {
-    final monthsMatch = monthsRegex.firstMatch(durationString);
-    if (monthsMatch != null) {
-      final monthNumber = monthsMatch.group(1);
-      if (monthNumber != null) {
-        duration = addTwoDurations(duration, Duration(days: 30 * int.parse(monthNumber)));
-      }
-    }
-  }
+  for (final entry in elements.entries) {
+    final pattern = entry.key;
+    final value = entry.value;
 
-  if (matchDays) {
-    final daysMatch = daysRegex.firstMatch(durationString);
-    if (daysMatch != null) {
-      final daysNumber = daysMatch.group(1);
-      if (daysNumber != null) {
-        duration = addTwoDurations(duration, Duration(days: int.parse(daysNumber)));
-      }
-    }
-  }
+    final match = pattern.firstMatch(durationString);
+    if (match != null) {
+      final amountText = match.group(1);
+      assert(amountText != null, 'Invalid pattern was provided');
 
-  if (matchHours) {
-    final hoursMatch = hoursRegex.firstMatch(durationString);
-    if (hoursMatch != null) {
-      final hoursNumber = hoursMatch.group(1);
-      if (hoursNumber != null) {
-        duration = addTwoDurations(duration, Duration(hours: int.parse(hoursNumber)));
-      }
-    }
-  }
-
-  if (matchMinutes) {
-    final minutesMatch = minutesRegex.firstMatch(durationString);
-    if (minutesMatch != null) {
-      final minutesNumber = minutesMatch.group(1);
-      if (minutesNumber != null) {
-        duration = addTwoDurations(duration, Duration(minutes: int.parse(minutesNumber)));
-      }
-    }
-  }
-
-  if (matchSeconds) {
-    final secondsMatch = secondsRegex.firstMatch(durationString);
-    if (secondsMatch != null) {
-      final secondNumber = secondsMatch.group(1);
-      if (secondNumber != null) {
-        duration = addTwoDurations(duration, Duration(seconds: int.parse(secondNumber)));
+      final amount = int.tryParse(amountText!);
+      if (amount != null) {
+        duration += value(amount);
       }
     }
   }

--- a/lib/src/human_duration_parser.dart
+++ b/lib/src/human_duration_parser.dart
@@ -1,11 +1,11 @@
 library duration_parser;
 
-final yearsRegex = RegExp(r"(\d+)([ ]*)(years|year|y)");
-final monthsRegex = RegExp(r"(\d+)([ ]*)(months|month|mon)");
-final daysRegex = RegExp(r"(\d+)([ ]*)(days|day|d)");
-final hoursRegex = RegExp(r"(\d+)([ ]*)(hours|hour|h)");
-final minutesRegex = RegExp(r"(\d+)([ ]*)(minutes|minute|min|m)");
-final secondsRegex = RegExp(r"(\d+)([ ]*)(seconds|second|secs|sec|s)");
+final yearsRegex = RegExp(r"(-?\d+)([ ]*)(years|year|y)");
+final monthsRegex = RegExp(r"(-?\d+)([ ]*)(months|month|mon)");
+final daysRegex = RegExp(r"(-?\d+)([ ]*)(days|day|d)");
+final hoursRegex = RegExp(r"(-?\d+)([ ]*)(hours|hour|h)");
+final minutesRegex = RegExp(r"(-?\d+)([ ]*)(minutes|minute|min|m)");
+final secondsRegex = RegExp(r"(-?\d+)([ ]*)(seconds|second|secs|sec|s)");
 
 Duration _computeYears(int years) {
   final now = DateTime.now();
@@ -30,7 +30,7 @@ Duration? parseStringToDuration(
   bool matchMinutes = true,
   bool matchSeconds = true,
   bool matchMilliSeconds = true,
-  bool allowNegative = true,
+  bool allowNegative = false,
 }) {
   var duration = Duration.zero;
   bool parsed = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.0.1
 homepage: https://github.com/l7ssha/duration_parser
 
 environment:
-  sdk: '>=2.14.3 <3.0.0'
+  sdk: '>2.19.0-440.0.dev <3.0.0'
 
 dev_dependencies:
   lints: ^1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: human_duration_parser
 description: Parse human readable duration into Dart's duration
-version: 2.0.1
+version: 3.0.0
 homepage: https://github.com/l7ssha/duration_parser
 
 environment:

--- a/test/human_duration_parser_test.dart
+++ b/test/human_duration_parser_test.dart
@@ -7,9 +7,9 @@ void main() {
     final yearResult = parseStringToDuration("1 year");
     final yResult = parseStringToDuration("1y");
 
-    expect(365, equals(yearsResult.inDays));
-    expect(365, equals(yearResult.inDays));
-    expect(365, equals(yResult.inDays));
+    expect(365, equals(yearsResult?.inDays));
+    expect(365, equals(yearResult?.inDays));
+    expect(365, equals(yResult?.inDays));
   });
 
   test("months test", () {
@@ -17,9 +17,9 @@ void main() {
     final monthResult = parseStringToDuration("1 month");
     final mResult = parseStringToDuration("3mon");
 
-    expect(60, equals(monthsResult.inDays));
-    expect(30, equals(monthResult.inDays));
-    expect(90, equals(mResult.inDays));
+    expect(60, equals(monthsResult?.inDays));
+    expect(30, equals(monthResult?.inDays));
+    expect(90, equals(mResult?.inDays));
   });
 
   test("days test", () {
@@ -27,9 +27,9 @@ void main() {
     final dayResult = parseStringToDuration("1 day");
     final dResult = parseStringToDuration("3d");
 
-    expect(2, equals(daysResult.inDays));
-    expect(1, equals(dayResult.inDays));
-    expect(3, equals(dResult.inDays));
+    expect(2, equals(daysResult?.inDays));
+    expect(1, equals(dayResult?.inDays));
+    expect(3, equals(dResult?.inDays));
   });
 
   test("hours test", () {
@@ -37,9 +37,9 @@ void main() {
     final hourResult = parseStringToDuration("1 hour");
     final hResult = parseStringToDuration("3h");
 
-    expect(2, equals(hoursResult.inHours));
-    expect(1, equals(hourResult.inHours));
-    expect(3, equals(hResult.inHours));
+    expect(2, equals(hoursResult?.inHours));
+    expect(1, equals(hourResult?.inHours));
+    expect(3, equals(hResult?.inHours));
   });
 
   test("minutes test", () {
@@ -48,10 +48,10 @@ void main() {
     final minResult = parseStringToDuration("4 min");
     final mResult = parseStringToDuration("3m");
 
-    expect(2, equals(minutesResult.inMinutes));
-    expect(4, equals(minResult.inMinutes));
-    expect(1, equals(minuteResult.inMinutes));
-    expect(3, equals(mResult.inMinutes));
+    expect(2, equals(minutesResult?.inMinutes));
+    expect(4, equals(minResult?.inMinutes));
+    expect(1, equals(minuteResult?.inMinutes));
+    expect(3, equals(mResult?.inMinutes));
   });
 
   test("seconds test", () {
@@ -61,10 +61,10 @@ void main() {
     final secResult = parseStringToDuration("1 sec");
     final sResult = parseStringToDuration("3s");
 
-    expect(2, equals(secondsResult.inSeconds));
-    expect(4, equals(secsResult.inSeconds));
-    expect(1, equals(secondResult.inSeconds));
-    expect(1, equals(secResult.inSeconds));
-    expect(3, equals(sResult.inSeconds));
+    expect(2, equals(secondsResult?.inSeconds));
+    expect(4, equals(secsResult?.inSeconds));
+    expect(1, equals(secondResult?.inSeconds));
+    expect(1, equals(secResult?.inSeconds));
+    expect(3, equals(sResult?.inSeconds));
   });
 }


### PR DESCRIPTION
This is a small PR containing a few QOL features that I felt were missing. They're breaking, so I also added the 3.0.0 release and changelog.

Release includes:
- `null` return when parsing fails
- Better year/month handling*
- Support parsing & blocking negative values


* TODO: maybe we should handle days the same to account for DST? The issue with DST is that it is not synchronised worldwide, so servers in one timezone might give different results to servers in another - this is also the case with months and years but has less of an impact in those cases.